### PR TITLE
Get parquet row groups data

### DIFF
--- a/Package.nuspec
+++ b/Package.nuspec
@@ -2,14 +2,14 @@
 <package >
   <metadata>
     <id>pq2json</id>
-    <version>0.1.10</version>
+    <version>0.1.11</version>
     <authors>Evgeney Ryzhyk</authors>
     <owners>Evgeney Ryzhyk</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/Azure/azure-kusto-parquet-conv</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Parquet to JSON (line delimited) converter tool.</description>
-    <releaseNotes>Added support for producing empty values for columns missing from the file</releaseNotes>
+    <releaseNotes>Added optional argument to return row groups metadata</releaseNotes>
     <copyright>Copyright 2020</copyright>
     <tags></tags>
     <dependencies></dependencies>

--- a/pq2json/Cargo.toml
+++ b/pq2json/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 clap = "2"
 parquet = { git = "https://github.com/rzheka/arrow.git", branch = "dev" }
 itertools = "0.8"
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 num-bigint = "0.2"
 chrono = "0.4"

--- a/pq2json/Cargo.toml
+++ b/pq2json/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 clap = "2"
 parquet = { git = "https://github.com/rzheka/arrow.git", branch = "dev" }
 itertools = "0.8"
-serde = { version = "1", features = ["derive"] }
+serde = "1"
 serde_json = "1"
 num-bigint = "0.2"
 chrono = "0.4"

--- a/pq2json/src/main.rs
+++ b/pq2json/src/main.rs
@@ -102,6 +102,13 @@ fn main() {
                 .takes_value(false)
                 .required(false),
         )
+		.arg(
+            Arg::with_name("rowgroups")
+                .long("rowgroups")
+                .help("Print Row Groups Metadata")
+                .takes_value(false)
+                .required(false),
+        )
         .arg(
             Arg::with_name("INPUT")
                 .help("Input file to use")
@@ -142,6 +149,8 @@ fn main() {
         schema::print_schema(input)
     } else if matches.is_present("cslschema") {
         schema::print_csl_schema(input)
+    } else if matches.is_present("rowgroups") {
+        schema::print_row_groups_metadata(input)
     } else {
         converter::convert(&settings, input, output)
     };

--- a/pq2json/src/main.rs
+++ b/pq2json/src/main.rs
@@ -102,7 +102,7 @@ fn main() {
                 .takes_value(false)
                 .required(false),
         )
-		.arg(
+        .arg(
             Arg::with_name("rowgroups")
                 .long("rowgroups")
                 .help("Print Row Groups Metadata")

--- a/pq2json/src/schema.rs
+++ b/pq2json/src/schema.rs
@@ -8,7 +8,6 @@ use parquet::file::reader::{FileReader, SerializedFileReader};
 use parquet::schema::printer::{print_file_metadata, print_parquet_metadata};
 use parquet::schema::types::Type;
 use serde_json::Value;
-use serde::Serialize;
 
 /// Prints Parquet file schema information
 ///
@@ -119,7 +118,6 @@ fn field_csl_schema(field_type: &Type) -> (&str, &str) {
 pub fn print_row_groups_metadata(input_file: &str) -> Result<(), Box<dyn Error>> {
     let file = File::open(&Path::new(input_file))?;
     let reader = SerializedFileReader::new(file)?;
-    let row_groups_count = reader.metadata().num_row_groups();
     let row_groups = Value::Array(
         reader
             .metadata()
@@ -140,16 +138,6 @@ pub fn print_row_groups_metadata(input_file: &str) -> Result<(), Box<dyn Error>>
             .collect_vec(),
     );
 
-    let row_groups_object = RowGroups {
-        count: row_groups_count,
-        row_groups,
-    };
-    println!("{}", serde_json::to_string(&row_groups_object)?);
+    println!("{}", serde_json::to_string(&row_groups)?);
     Ok(())
-}
-
-#[derive(Serialize)]
-pub struct RowGroups {
-    pub count: usize,
-    pub row_groups: Value,
 }


### PR DESCRIPTION
Prints information regarding row groups in a parquet file - their total size and number of rows, to be used when parallelizing parquet file reading by row groups.